### PR TITLE
Use AppConfig to set default settings

### DIFF
--- a/keycloak_oidc/apps.py
+++ b/keycloak_oidc/apps.py
@@ -1,0 +1,17 @@
+from django.apps import AppConfig
+from django.conf import settings
+
+from . import default_settings as defaults
+
+
+class KeycloakOIDCConfig(AppConfig):
+    name = 'keycloak_oidc'
+
+    def ready(self):
+        # Here we inject settings defined in default_settings. We can not use the
+        # classic app_settings architecture with getattr(settings, 'SETTINGS_NAME', default),
+        # because the defaults are not used by our app, but by mozilla django oidc.
+        # Therefore we need to inject them.
+        for name in dir(defaults):
+            if name.isupper() and not hasattr(settings, name):
+                setattr(settings, name, getattr(defaults, name))

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ extra_requirements = {
 
 setup(
     name='datapunt-keycloak-oidc',
-    version='0.3',
+    version='0.4',
     license='Mozilla Public License 2.0',
 
     author='Datapunt Amsterdam',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -75,3 +75,5 @@ OIDC_OP_JWKS_ENDPOINT = os.getenv(
     'OIDC_OP_JWKS_ENDPOINT', 'https://iam.amsterdam.nl/auth/realms/datapunt-acc/protocol/openid-connect/certs')
 OIDC_OP_LOGOUT_ENDPOINT = os.getenv(
     'OIDC_OP_LOGOUT_ENDPOINT', 'https://iam.amsterdam.nl/auth/realms/datapunt-acc/protocol/openid-connect/logout')
+
+LOGOUT_REDIRECT_URL = 'test'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from django.test import TestCase
+
+
+class TestSettings(TestCase):
+
+    def test_injected_settings(self):
+        # test that our default settings have been injected into the global settings
+        self.assertEqual(settings.OIDC_OP_LOGOUT_URL_METHOD, 'keycloak_oidc.utils.oidc_op_logout',
+                         f'Expected "OIDC_OP_LOGOUT_URL_METHOD" to be injected into settings')
+        self.assertEqual(settings.OIDC_USERNAME_ALGO, 'keycloak_oidc.utils.generate_username',
+                         f'Expected "OIDC_USERNAME_ALGO" to be injected into settings')
+        self.assertEqual(settings.OIDC_RP_SIGN_ALGO, 'RS256',
+                         f'Expected "OIDC_RP_SIGN_ALGO" to be injected into settings')
+        self.assertEqual(settings.OIDC_RP_SCOPES, 'openid email',
+                         f'Expected "OIDC_RP_SCOPES" to be injected into settings')
+
+        self.assertEqual(settings.LOGIN_URL, 'oidc_authentication_init',
+                         f'Expected "LOGIN_URL" to be injected into settings')
+        self.assertEqual(settings.LOGIN_REDIRECT_URL, '/',
+                         f'Expected "LOGIN_REDIRECT_URL" to be injected into settings')
+
+        # test that the 'client' settings (in tests/settings.py) are properly loaded
+        self.assertEqual(settings.OIDC_RP_CLIENT_ID, "test")
+        self.assertEqual(settings.OIDC_RP_CLIENT_SECRET, "test")
+
+        # test that the 'client' settings properly override the defailts
+        self.assertEqual(settings.LOGOUT_REDIRECT_URL, 'test',
+                         f'Expected "LOGOUT_REDIRECT_URL" to be injected into settings')


### PR DESCRIPTION
We want to set default values for settings used in the mozilla django oidc library. We do that by injecting them into the global settings in the AppConfig.ready().